### PR TITLE
Add settings for SLU makerspace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.18</version>
+            <version>1.4.19</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/de/thomas_oster/visicut/misc/LabSettings.java
+++ b/src/main/java/de/thomas_oster/visicut/misc/LabSettings.java
@@ -70,6 +70,7 @@ public class LabSettings
     result.add(new LabSettings("Germany, Dresden: Konglomerat e.V.", "https://github.com/konglomerat/visicut-settings/archive/master.zip"));
     result.add(new LabSettings("Germany, Dresden: Makerspace Dresden", "https://github.com/Makerspace-Dresden/visicut-settings/archive/master.zip"));
     result.add(new LabSettings("Germany, Erlangen: FAU FabLab", "https://github.com/fau-fablab/visicut-settings/archive/master.zip", new String[]{".fau.de", ".uni-erlangen.de"}, null));
+    result.add(new LabSettings("Germany, Erlangen: ZAM", "https://github.com/zam-haus/visicut-settings/archive/refs/heads/main.zip", null, new String[]{"ZAM"}));
     result.add(new LabSettings("Germany, Hamburg: Fab Lab Fabulous St. Pauli", "https://github.com/Fab-Lab-Fabulous-St-Pauli/visicut-settings/archive/main.zip", new String[]{".fablab-hamburg.org"}, null));
     result.add(new LabSettings("Germany, Heidelberg: Heidelberg Makerspace", "https://github.com/heidelberg-makerspace/visicut-settings/archive/master.zip"));
     result.add(new LabSettings("Germany, Nuremberg: Fab lab Region Nürnberg e.V.", "https://github.com/fablabnbg/visicut-settings/archive/master.zip"));

--- a/src/main/java/de/thomas_oster/visicut/misc/LabSettings.java
+++ b/src/main/java/de/thomas_oster/visicut/misc/LabSettings.java
@@ -80,6 +80,7 @@ public class LabSettings
     result.add(new LabSettings("Netherlands, Enschede: TkkrLab", "https://github.com/TkkrLab/visicut-settings/archive/master.zip"));
     result.add(new LabSettings("United Kingdom, Leeds: Hackspace", "https://github.com/leedshackspace/visicut-settings/archive/master.zip"));
     result.add(new LabSettings("United States, Seattle: Fremont Hangar", "https://github.com/hghile/visicut-settings/archive/master.zip", null, new String[]{"WL-seattle-maker-space"}));
+    result.add(new LabSettings("United States, Seattle: SLU Makerspace", "https://github.com/hghile/visicut-settings-slu/archive/master.zip", null, new String[]{"WL-slu-makerspace"})); 
     return result;
   }
 }


### PR DESCRIPTION
Add a new link for SLU makerspace settings.

Took me a bit to find the new file location.. would be nice to update the example link in https://github.com/t-oster/VisiCut/wiki/How-to-add-default-settings-for-your-lab